### PR TITLE
新規チャットボタンを残すように修正した

### DIFF
--- a/hojingpt-delete-toolbar.js
+++ b/hojingpt-delete-toolbar.js
@@ -1,10 +1,27 @@
 (function() {
-  // ここに実際に実行したいJavaScriptコードを記述する
-  // 両脇のサイドバーとヘッダーをなくす
   document.querySelector(".toolbar").remove();
   document.querySelector(".navbar").remove();
   document.querySelector(".chat-header").remove();
   document.querySelector('.content-wrapper').style.paddingTop = '0px';
-  document.querySelector('.threads').style.width = '0px';
+  document.querySelector(".threads-mid").remove();
+  document.querySelector(".threads-bottom").remove();
+  document.querySelector('.threads').style.borderRight = '0px';
+  removeButtonText();
+  const divElement = document.querySelector('div.d-grid.p-3');
+  if (divElement) {
+    divElement.style.setProperty('padding', '0rem', 'important');
+  }
+  const iconElement = document.querySelector('span.plus-icon.white.icon');
+  if (iconElement) {
+    iconElement.style.marginRight = '0rem';
+  }
   console.log('JavaScript executed');
 })();
+
+function removeButtonText() {
+  const button = document.querySelector('button[onclick="thread_create()"]');
+  button.innerHTML = '';
+  const iconSpan = document.createElement('span');
+  iconSpan.className = 'plus-icon white icon';
+  button.appendChild(iconSpan);
+}


### PR DESCRIPTION
## 目的
チャットを変えられるようにしないと、会話が成り立たなくなっていくためボタンを残した

## 変更点
変更前
![image](https://github.com/user-attachments/assets/1ca1244e-edaf-43ba-b136-54bb0e9868f3)

js実行後
![image](https://github.com/user-attachments/assets/b81d7a3f-3ef2-421f-b586-c1c3cdeace14)
